### PR TITLE
Use localized incident titles and messages

### DIFF
--- a/_i18n/i18n_de.properties
+++ b/_i18n/i18n_de.properties
@@ -1,0 +1,30 @@
+
+#XFLD,120: Label for a filter field
+Urgency=Dringlichkeit
+
+#XFLD,120: Label for a filter field
+Status=Status
+
+#XFLD,120: Label for a column title
+Title=Titel
+
+#XFLD,120: Label for a column title
+Customer=Kunde
+
+#XFLD,50: Label for a section
+Details=Details
+
+#XFLD,50: Label for a section
+Conversations=Konversationen
+
+#XFLD,120: Label for a column title
+Author=Autor
+
+#XFLD,120: Label for a column title
+Timestamp=Zeitstempel
+
+#XFLD,120: Label for a column title
+Message=Nachricht
+
+#XFLD,50: Label for a section
+Overview=Übersicht

--- a/app/incidents/webapp/i18n/i18n_de.properties
+++ b/app/incidents/webapp/i18n/i18n_de.properties
@@ -1,0 +1,9 @@
+# This is the resource bundle for ns.incidents
+
+#Texts for manifest.json
+
+#XTIT: Application name
+appTitle=Incident-Management
+
+#YDES: Application description
+appDescription=Eine Fiori-Anwendung.

--- a/db/data/sap.capire.incidents-Conversations.csv
+++ b/db/data/sap.capire.incidents-Conversations.csv
@@ -1,5 +1,5 @@
 ID,incidents_ID,timestamp,author,message
 2b23bb4b-4ac7-4a24-ac02-aa10cabd842c,3b23bb4b-4ac7-4a24-ac02-aa10cabd842c,1995-12-17T03:24:00Z,Harry John,Can you please check if battery connections are fine?
 2b23bb4b-4ac7-4a24-ac02-aa10cabd843c,3a4ede72-244a-4f5f-8efa-b17e032d01ee,1995-12-18T04:24:00Z,Emily Elizabeth,Can you please check if there are any loose connections?
-9583f982-d7df-4aad-ab26-301d4a157cd7,3583f982-d7df-4aad-ab26-301d4a157cd7,2022-09-04T12:00:00Z,Sunny Sunshine, please check why the solar panel is broken
+9583f982-d7df-4aad-ab26-301d4a157cd7,3583f982-d7df-4aad-ab26-301d4a157cd7,2022-09-04T12:00:00Z,Sunny Sunshine,Please check why the solar panel is broken
 9583f982-d7df-4aad-ab26-301d4a158cd7,3ccf474c-3881-44b7-99fb-59a2a4668418,2022-09-04T13:00:00Z,Bradley Flowers,What exactly is wrong?

--- a/db/data/sap.capire.incidents-Conversations_texts.csv
+++ b/db/data/sap.capire.incidents-Conversations_texts.csv
@@ -1,0 +1,5 @@
+ID;locale;message
+2b23bb4b-4ac7-4a24-ac02-aa10cabd842c;de;Können Sie bitte überprüfen, ob die Batterieanschlüsse in Ordnung sind?
+2b23bb4b-4ac7-4a24-ac02-aa10cabd843c;de;Können Sie bitte überprüfen, ob es lose Verbindungen gibt?
+9583f982-d7df-4aad-ab26-301d4a157cd7;de;Bitte prüfen Sie, warum das Solarpanel defekt ist
+9583f982-d7df-4aad-ab26-301d4a158cd7;de;Was genau ist falsch?

--- a/db/data/sap.capire.incidents-Incidents_texts.csv
+++ b/db/data/sap.capire.incidents-Incidents_texts.csv
@@ -1,0 +1,5 @@
+ID,locale,title
+3b23bb4b-4ac7-4a24-ac02-aa10cabd842c,de,Wechselrichter nicht funktionsfähig
+3a4ede72-244a-4f5f-8efa-b17e032d01ee,de,An einem sonnigen Tag gibt es keine Strömung
+3ccf474c-3881-44b7-99fb-59a2a4668418,de,Seltsames Geräusch beim Ausschalten des Wechselrichters
+3583f982-d7df-4aad-ab26-301d4a157cd7,de,Solarpanel kaputt

--- a/db/data/sap.capire.incidents-Status_texts.csv
+++ b/db/data/sap.capire.incidents-Status_texts.csv
@@ -1,0 +1,7 @@
+Code,locale,descr
+N,de,Neu
+A,de,Zugewiesen
+I,de,In Bearbeitung
+H,de,In der Warteschleife
+R,de,Gelöst
+C,de,Geschlossen

--- a/db/data/sap.capire.incidents-Urgency_texts.csv
+++ b/db/data/sap.capire.incidents-Urgency_texts.csv
@@ -1,0 +1,4 @@
+code;locale;descr
+H;de;hoch
+M;de;mittel
+L;de;niedrig

--- a/db/schema.cds
+++ b/db/schema.cds
@@ -21,7 +21,7 @@ entity Customers : cuid, managed {
  */
 entity Incidents : cuid, managed {
    customer     : Association to Customers;
-   title        : String  @title : 'Title';
+   title        : localized String  @title : 'Title';
    urgency      : Association to Urgency;
    status       : Association to Status;
    conversations: Composition of many Conversations on conversations.incidents = $self;
@@ -36,7 +36,7 @@ entity Status : CodeList {
         resolved = 'R';
         closed = 'C';
 };
-    criticality : Integer; 
+    criticality : Integer;
 }
 
 entity Urgency : CodeList {
@@ -51,7 +51,7 @@ entity Urgency : CodeList {
          incidents : Association to Incidents;
          timestamp : DateTime;
          author    : String @cds.on.insert: $user;
-         message   : String;
+         message   : localized String;
    }
 
 type EMailAddress : String;


### PR DESCRIPTION
- Use *localized* for incident titles and messages to match the browser's language
- Added model and data translations for language *de* (this is the only one I can truly verify)

@DanSchlachter:  Do we want to keep both model and data translations? Also, for which languages?